### PR TITLE
refactor(thread): use thread-local singleton pattern for ThreadCalc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,12 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,17 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
+ "windows-targets",
 ]
 
 [[package]]
@@ -424,16 +408,13 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minacalc-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bindgen",
  "cc",
  "env_logger",
  "log",
- "once_cell",
- "parking_lot",
  "rhythm-open-exchange",
- "rosu-map",
 ]
 
 [[package]]
@@ -483,29 +464,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "pkg-config"
@@ -630,15 +588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,12 +674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rosu-map"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92ea634d8b3eaa4d7fba7bd12045dda1a50ce81401c96af0d9c851b0737544"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,12 +690,6 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -832,12 +769,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -1002,42 +933,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
  "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1047,21 +956,9 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1071,21 +968,9 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1095,33 +980,15 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minacalc-rs"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Rust bindings for MinaCalc C++ library (Etterna rating calculator)"
 license = "MIT"
@@ -15,16 +15,13 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["hashmap"]
-thread = ["dep:parking_lot", "dep:once_cell"]
+thread = []
 hashmap = []
 rox = []
 utils = []
 api = ["rox"]
 
 [dependencies]
-parking_lot = { version = "0.12", optional = true }
-rosu-map = { version = "0.2.1", optional = true }
-once_cell = { version = "1.19", optional = true }
 rhythm-open-exchange = "0.4.0"
 log = "0.4"
 env_logger = "0.11"
@@ -53,3 +50,8 @@ required-features = ["utils"]
 name = "msd"
 path = "src/bin/msd.rs"
 required-features = ["rox"]
+
+[[example]]
+name = "multithread"
+path = "examples/multithread.rs"
+required-features = ["thread", "rox"]

--- a/bindings/csharp/MinaCalc.csproj
+++ b/bindings/csharp/MinaCalc.csproj
@@ -9,7 +9,7 @@
     <Authors>Glubus</Authors>
     <Description>C# bindings for MinaCalc, a rhythm game difficulty calculator.</Description>
     <PackageId>MinaCalc</PackageId>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <PackageTags>rhythm-game;difficulty-calculator;native;rust;minacalc</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Glubus/minacalc-rs</RepositoryUrl>

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minacalc-python"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Python bindings for minacalc-rs (Etterna rating calculator)"
 license = "MIT"
@@ -18,6 +18,3 @@ minacalc-rs = { path = "../..", features = [
     "utils",
 ] }
 pyo3 = { version = "0.27", features = ["extension-module"] }
-
-
-

--- a/examples/multithread.rs
+++ b/examples/multithread.rs
@@ -1,0 +1,104 @@
+//! Example: Multi-threaded chart calculation
+//!
+//! Demonstrates using ThreadCalc to calculate multiple charts concurrently.
+
+use minacalc_rs::rox::calc::high_level::RoxCalcExt;
+use minacalc_rs::thread::ThreadCalc;
+use std::path::PathBuf;
+use std::thread;
+use std::time::Instant;
+
+fn main() {
+    // Find all chart files in assets directory
+    let assets_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets");
+
+    let chart_files: Vec<PathBuf> = std::fs::read_dir(&assets_dir)
+        .expect("Failed to read assets directory")
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .map(|ext| {
+                    let ext = ext.to_string_lossy().to_lowercase();
+                    ext == "osu" || ext == "sm" || ext == "ssc"
+                })
+                .unwrap_or(false)
+        })
+        .collect();
+
+    println!(
+        "Found {} chart files in {:?}",
+        chart_files.len(),
+        assets_dir
+    );
+
+    if chart_files.is_empty() {
+        println!("No chart files found! Add .osu, .sm, or .ssc files to assets/");
+        return;
+    }
+
+    // Calculate all charts in parallel using threads
+    let start = Instant::now();
+
+    let handles: Vec<_> = chart_files
+        .into_iter()
+        .map(|path| {
+            thread::spawn(move || {
+                // Each thread gets its own ThreadCalc (thread-local singleton)
+                let calc = ThreadCalc::new().expect("Failed to create ThreadCalc");
+
+                let result = calc.calculate_at_rate_from_file(
+                    &path, 1.0,  // music rate
+                    0.93, // score goal
+                    None, // chart rate
+                    true, // capped (SSR mode)
+                );
+
+                match result {
+                    Ok(scores) => {
+                        println!(
+                            "[{:?}] {} -> Overall: {:.2}",
+                            thread::current().id(),
+                            path.file_name().unwrap().to_string_lossy(),
+                            scores.overall
+                        );
+                        Some((path, scores))
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "[{:?}] {} -> Error: {}",
+                            thread::current().id(),
+                            path.file_name().unwrap().to_string_lossy(),
+                            e
+                        );
+                        None
+                    }
+                }
+            })
+        })
+        .collect();
+
+    // Collect results
+    let results: Vec<_> = handles
+        .into_iter()
+        .filter_map(|h| h.join().ok().flatten())
+        .collect();
+
+    let elapsed = start.elapsed();
+
+    println!("\n=== Results ===");
+    println!("Calculated {} charts in {:?}", results.len(), elapsed);
+
+    for (path, scores) in &results {
+        println!(
+            "  {} -> O:{:.2} S:{:.2} JS:{:.2} HS:{:.2} CJ:{:.2} T:{:.2}",
+            path.file_name().unwrap().to_string_lossy(),
+            scores.overall,
+            scores.stream,
+            scores.jumpstream,
+            scores.handstream,
+            scores.chordjack,
+            scores.technical
+        );
+    }
+}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,106 +1,436 @@
+//! Thread-safe calculator using thread-local singleton pattern.
+//!
+//! When this feature is enabled, each thread gets exactly ONE `Calc` instance
+//! that is reused for all calculations. This matches the C++ MinaCalc pattern.
+
 use crate::error::{MinaCalcError, MinaCalcResult};
-use crate::Calc;
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
-use std::sync::Arc;
+use crate::wrapper::{AllRates, Note, SkillsetScores};
+use crate::{CalcHandle, NoteInfo};
+use log::debug;
+use std::cell::RefCell;
 
-// SAFETY: We assume CalcHandle is thread-safe from C++
-// If this is not the case, remove these implementations
-unsafe impl Send for Calc {}
-unsafe impl Sync for Calc {}
-
-/// Thread-safe calculator pool
-pub struct ThreadSafeCalcPool {
-    calculators: Arc<Mutex<Vec<Calc>>>,
+// Thread-local calculator singleton (matches C++ pattern exactly)
+thread_local! {
+    static THREAD_CALC: RefCell<Option<*mut CalcHandle>> = const { RefCell::new(None) };
 }
 
-/// Global calculator pool for thread-safe access
-pub static GLOBAL_CALC_POOL: Lazy<ThreadSafeCalcPool> = Lazy::new(|| ThreadSafeCalcPool {
-    calculators: Arc::new(Mutex::new(Vec::new())),
-});
+/// Thread-safe calculator that uses thread-local storage.
+///
+/// This struct can be created multiple times, but all instances on the same
+/// thread share the same underlying C++ calculator. This is the recommended
+/// way to use MinaCalc in multi-threaded contexts.
+///
+/// # Example
+/// ```ignore
+/// use minacalc::thread::ThreadCalc;
+///
+/// // First call initializes the thread-local calculator
+/// let calc = ThreadCalc::new()?;
+///
+/// // Subsequent calls reuse the same calculator
+/// let calc2 = ThreadCalc::new()?;
+///
+/// // Both calc and calc2 use the same underlying C++ instance
+/// ```
+pub struct ThreadCalc {
+    // Marker to prevent Send/Sync (thread-local only)
+    _marker: std::marker::PhantomData<*mut ()>,
+}
 
-impl ThreadSafeCalcPool {
-    /// Gets or creates a calculator instance from the pool
-    pub fn get_calc(&self) -> MinaCalcResult<Calc> {
-        let mut calculators = self.calculators.lock();
+impl ThreadCalc {
+    /// Creates or gets the thread-local calculator.
+    ///
+    /// First call on a thread initializes the calculator.
+    /// Subsequent calls return immediately without allocation.
+    pub fn new() -> MinaCalcResult<Self> {
+        THREAD_CALC.with(|calc_cell| {
+            let mut calc_ref = calc_cell.borrow_mut();
 
-        // Try to reuse an existing calculator
-        if let Some(calc) = calculators.pop() {
-            // Validate the calculator is still valid
-            if calc.is_valid() {
-                return Ok(calc);
-            }
-            // If invalid, continue to create a new one
-        }
-
-        // Create a new one if none available
-        Calc::new()
-    }
-
-    /// Returns a calculator to the pool
-    pub fn return_calc(&self, calc: Calc) {
-        // Only return valid calculators to the pool
-        if calc.is_valid() {
-            let mut calculators = self.calculators.lock();
-            calculators.push(calc);
-        }
-    }
-
-    /// Gets a calculator from the global pool
-    pub fn get_global_calc() -> MinaCalcResult<Calc> {
-        GLOBAL_CALC_POOL.get_calc()
-    }
-
-    /// Returns a calculator to the global pool
-    pub fn return_global_calc(calc: Calc) {
-        GLOBAL_CALC_POOL.return_calc(calc);
-    }
-
-    /// Gets the current pool size
-    pub fn pool_size(&self) -> usize {
-        let calculators = self.calculators.lock();
-        calculators.len()
-    }
-
-    /// Clears the pool (useful for cleanup)
-    pub fn clear_pool(&self) {
-        let mut calculators = self.calculators.lock();
-        calculators.clear();
-    }
-
-    /// Pre-populates the pool with a specified number of calculators
-    pub fn pre_populate(&self, count: usize) -> MinaCalcResult<()> {
-        let mut calculators = self.calculators.lock();
-
-        for _ in 0..count {
-            let calc = Calc::new()?;
-            calculators.push(calc);
-        }
-
-        Ok(())
-    }
-
-    /// Gets a calculator with timeout (useful for avoiding deadlocks)
-    pub fn get_calc_with_timeout(&self, timeout_ms: u64) -> MinaCalcResult<Calc> {
-        use std::time::{Duration, Instant};
-
-        let start = Instant::now();
-        let timeout = Duration::from_millis(timeout_ms);
-
-        loop {
-            match self.get_calc() {
-                Ok(calc) => return Ok(calc),
-                Err(_e) => {
-                    if start.elapsed() >= timeout {
-                        return Err(MinaCalcError::InternalError(format!(
-                            "Timeout waiting for calculator: {}ms",
-                            timeout_ms
-                        )));
-                    }
-                    // Small delay before retry
-                    std::thread::sleep(Duration::from_millis(1));
+            if calc_ref.is_none() {
+                debug!("Initializing thread-local Calc instance");
+                let handle = unsafe { crate::create_calc() };
+                if handle.is_null() {
+                    return Err(MinaCalcError::CalculatorCreationFailed);
                 }
+                *calc_ref = Some(handle);
+                debug!("Thread-local Calc initialized successfully");
             }
+
+            Ok(ThreadCalc {
+                _marker: std::marker::PhantomData,
+            })
+        })
+    }
+
+    /// Gets the calculator version.
+    pub fn version() -> i32 {
+        unsafe { crate::calc_version() }
+    }
+
+    /// Calculates SSR at a specific rate.
+    pub fn calc_ssr(
+        &self,
+        notes: &[Note],
+        music_rate: f32,
+        score_goal: f32,
+    ) -> MinaCalcResult<SkillsetScores> {
+        self.calc_at_rate(notes, music_rate, score_goal, true)
+    }
+
+    /// Calculates MSD at a specific rate.
+    pub fn calc_msd(
+        &self,
+        notes: &[Note],
+        music_rate: f32,
+        score_goal: f32,
+    ) -> MinaCalcResult<SkillsetScores> {
+        self.calc_at_rate(notes, music_rate, score_goal, false)
+    }
+
+    /// Calculates scores for a specific music rate.
+    pub fn calc_at_rate(
+        &self,
+        notes: &[Note],
+        music_rate: f32,
+        score_goal: f32,
+        capped: bool,
+    ) -> MinaCalcResult<SkillsetScores> {
+        if notes.is_empty() {
+            return Err(MinaCalcError::NoNotesProvided);
         }
+        if music_rate <= 0.0 {
+            return Err(MinaCalcError::InvalidMusicRate(music_rate));
+        }
+        if !(0.0..=1.0).contains(&score_goal) {
+            return Err(MinaCalcError::InvalidScoreGoal(score_goal));
+        }
+
+        for note in notes {
+            note.validate()?;
+        }
+
+        let mut note_infos: Vec<NoteInfo> = notes.iter().map(|&n| n.into()).collect();
+        let cap_int = i32::from(capped);
+
+        THREAD_CALC.with(|calc_cell| {
+            let calc_ref = calc_cell.borrow();
+            let handle = calc_ref.ok_or(MinaCalcError::CalculatorCreationFailed)?;
+
+            let result = unsafe {
+                crate::calc_at_rate(
+                    handle,
+                    note_infos.as_mut_ptr(),
+                    note_infos.len(),
+                    music_rate,
+                    score_goal,
+                    4,
+                    cap_int,
+                )
+            };
+
+            let scores: SkillsetScores = result.into();
+            scores.validate()?;
+            Ok(scores)
+        })
+    }
+
+    /// Calculates scores for all music rates.
+    pub fn calc_all_rates(&self, notes: &[Note], capped: bool) -> MinaCalcResult<AllRates> {
+        if notes.is_empty() {
+            return Err(MinaCalcError::NoNotesProvided);
+        }
+
+        for note in notes {
+            note.validate()?;
+        }
+
+        let mut note_infos: Vec<NoteInfo> = notes.iter().map(|&n| n.into()).collect();
+        let cap_int = i32::from(capped);
+
+        THREAD_CALC.with(|calc_cell| {
+            let calc_ref = calc_cell.borrow();
+            let handle = calc_ref.ok_or(MinaCalcError::CalculatorCreationFailed)?;
+
+            let result = unsafe {
+                crate::calc_all_rates(
+                    handle,
+                    note_infos.as_mut_ptr(),
+                    note_infos.len(),
+                    4,
+                    cap_int,
+                )
+            };
+
+            let msd: AllRates = result.into();
+            msd.validate()?;
+            Ok(msd)
+        })
+    }
+
+    /// Checks if this thread has an initialized calculator.
+    pub fn is_initialized() -> bool {
+        THREAD_CALC.with(|calc_cell| calc_cell.borrow().is_some())
+    }
+}
+
+// ============================================================================
+// Conditional trait implementations based on features
+// ============================================================================
+
+/// When `rox` feature is enabled, implement RoxCalcExt for ThreadCalc
+#[cfg(feature = "rox")]
+use crate::rox::calc::high_level::RoxCalcExt;
+
+#[cfg(feature = "rox")]
+impl RoxCalcExt for ThreadCalc {
+    fn calculate_at_rate_from_file<P: AsRef<std::path::Path>>(
+        &self,
+        path: P,
+        music_rate: f32,
+        score_goal: f32,
+        chart_rate: Option<f32>,
+        capped: bool,
+    ) -> MinaCalcResult<SkillsetScores> {
+        use crate::rox::convert::chart_to_notes;
+        use rhythm_open_exchange::codec::auto_decode;
+
+        let chart = auto_decode(path.as_ref()).map_err(|e| {
+            crate::error::RoxError::DecodeFailed(format!("Failed to decode: {}", e))
+        })?;
+        self.calculate_at_rate_from_rox_chart(&chart, music_rate, score_goal, chart_rate, capped)
+    }
+
+    fn calculate_at_rate_from_string(
+        &self,
+        content: &str,
+        _file_extension: &str,
+        music_rate: f32,
+        score_goal: f32,
+        chart_rate: Option<f32>,
+        capped: bool,
+    ) -> MinaCalcResult<SkillsetScores> {
+        use rhythm_open_exchange::codec::from_string;
+
+        let chart = from_string(content).map_err(|e| {
+            crate::error::RoxError::DecodeFailed(format!("Failed to decode: {}", e))
+        })?;
+        self.calculate_at_rate_from_rox_chart(&chart, music_rate, score_goal, chart_rate, capped)
+    }
+
+    fn calculate_at_rate_from_rox_chart(
+        &self,
+        chart: &rhythm_open_exchange::RoxChart,
+        music_rate: f32,
+        score_goal: f32,
+        chart_rate: Option<f32>,
+        capped: bool,
+    ) -> MinaCalcResult<SkillsetScores> {
+        use crate::rox::convert::chart_to_notes;
+
+        let notes = chart_to_notes(chart, chart_rate)?;
+        let keycount = chart.key_count() as u32;
+
+        if keycount != 4 && keycount != 6 && keycount != 7 {
+            return Err(crate::error::MinaCalcError::UnsupportedKeyCount(keycount));
+        }
+
+        let mut note_infos: Vec<NoteInfo> = notes.iter().map(|&n| n.into()).collect();
+        let cap_int = i32::from(capped);
+
+        THREAD_CALC.with(|calc_cell| {
+            let calc_ref = calc_cell.borrow();
+            let handle = calc_ref.ok_or(MinaCalcError::CalculatorCreationFailed)?;
+
+            let result = unsafe {
+                crate::calc_at_rate(
+                    handle,
+                    note_infos.as_mut_ptr(),
+                    note_infos.len(),
+                    music_rate,
+                    score_goal,
+                    keycount,
+                    cap_int,
+                )
+            };
+
+            let scores: SkillsetScores = result.into();
+            scores.validate()?;
+            Ok(scores)
+        })
+    }
+
+    fn calculate_all_rates_from_file<P: AsRef<std::path::Path>>(
+        &self,
+        path: P,
+        capped: bool,
+    ) -> MinaCalcResult<AllRates> {
+        use rhythm_open_exchange::codec::auto_decode;
+
+        let chart = auto_decode(path.as_ref()).map_err(|e| {
+            crate::error::RoxError::DecodeFailed(format!("Failed to decode: {}", e))
+        })?;
+        self.calculate_all_rates_from_rox_chart(&chart, capped)
+    }
+
+    fn calculate_all_rates_from_string(
+        &self,
+        content: &str,
+        _file_extension: &str,
+        capped: bool,
+    ) -> MinaCalcResult<AllRates> {
+        use rhythm_open_exchange::codec::from_string;
+
+        let chart = from_string(content).map_err(|e| {
+            crate::error::RoxError::DecodeFailed(format!("Failed to decode: {}", e))
+        })?;
+        self.calculate_all_rates_from_rox_chart(&chart, capped)
+    }
+
+    fn calculate_all_rates_from_rox_chart(
+        &self,
+        chart: &rhythm_open_exchange::RoxChart,
+        capped: bool,
+    ) -> MinaCalcResult<AllRates> {
+        use crate::rox::convert::chart_to_notes;
+
+        let notes = chart_to_notes(chart, None)?;
+        let keycount = chart.key_count() as u32;
+
+        if keycount != 4 && keycount != 6 && keycount != 7 {
+            return Err(crate::error::MinaCalcError::UnsupportedKeyCount(keycount));
+        }
+
+        let mut note_infos: Vec<NoteInfo> = notes.iter().map(|&n| n.into()).collect();
+        let cap_int = i32::from(capped);
+
+        THREAD_CALC.with(|calc_cell| {
+            let calc_ref = calc_cell.borrow();
+            let handle = calc_ref.ok_or(MinaCalcError::CalculatorCreationFailed)?;
+
+            let result = unsafe {
+                crate::calc_all_rates(
+                    handle,
+                    note_infos.as_mut_ptr(),
+                    note_infos.len(),
+                    keycount,
+                    cap_int,
+                )
+            };
+
+            let msd: AllRates = result.into();
+            msd.validate()?;
+            Ok(msd)
+        })
+    }
+}
+
+/// Convenience function: calculate SSR without creating ThreadCalc explicitly.
+pub fn calc_ssr(
+    notes: &[Note],
+    music_rate: f32,
+    score_goal: f32,
+) -> MinaCalcResult<SkillsetScores> {
+    ThreadCalc::new()?.calc_ssr(notes, music_rate, score_goal)
+}
+
+/// Convenience function: calculate MSD without creating ThreadCalc explicitly.
+pub fn calc_msd(
+    notes: &[Note],
+    music_rate: f32,
+    score_goal: f32,
+) -> MinaCalcResult<SkillsetScores> {
+    ThreadCalc::new()?.calc_msd(notes, music_rate, score_goal)
+}
+
+/// Convenience function: calculate all rates SSR.
+pub fn calc_all_rates_ssr(notes: &[Note]) -> MinaCalcResult<AllRates> {
+    ThreadCalc::new()?.calc_all_rates(notes, true)
+}
+
+/// Convenience function: calculate all rates MSD.
+pub fn calc_all_rates_msd(notes: &[Note]) -> MinaCalcResult<AllRates> {
+    ThreadCalc::new()?.calc_all_rates(notes, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_thread_calc_singleton() {
+        // First new
+        let calc1 = ThreadCalc::new().unwrap();
+        assert!(ThreadCalc::is_initialized());
+
+        // Second new - should reuse same underlying calc
+        let calc2 = ThreadCalc::new().unwrap();
+        assert!(ThreadCalc::is_initialized());
+
+        // Both should work
+        let notes = vec![
+            Note {
+                notes: 1,
+                row_time: 0.0,
+            },
+            Note {
+                notes: 2,
+                row_time: 0.5,
+            },
+        ];
+
+        let r1 = calc1.calc_ssr(&notes, 1.0, 0.93);
+        let r2 = calc2.calc_ssr(&notes, 1.0, 0.93);
+
+        assert!(r1.is_ok());
+        assert!(r2.is_ok());
+    }
+
+    #[test]
+    fn test_multithread_isolation() {
+        use std::thread;
+
+        let handles: Vec<_> = (0..4)
+            .map(|i| {
+                thread::spawn(move || {
+                    // Each thread gets its own calc
+                    let calc = ThreadCalc::new().unwrap();
+                    assert!(ThreadCalc::is_initialized());
+
+                    let notes = vec![
+                        Note {
+                            notes: 1,
+                            row_time: 0.0,
+                        },
+                        Note {
+                            notes: 2,
+                            row_time: 0.5 * (i as f32 + 1.0),
+                        },
+                    ];
+
+                    calc.calc_ssr(&notes, 1.0, 0.93)
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            assert!(handle.join().unwrap().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_convenience_functions() {
+        let notes = vec![
+            Note {
+                notes: 1,
+                row_time: 0.0,
+            },
+            Note {
+                notes: 2,
+                row_time: 0.5,
+            },
+        ];
+
+        assert!(calc_ssr(&notes, 1.0, 0.93).is_ok());
+        assert!(calc_msd(&notes, 1.0, 0.93).is_ok());
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -188,7 +188,9 @@ impl From<MsdForAllRates> for AllRates {
 }
 
 /// Main handler for difficulty calculations
-#[derive(Clone)]
+///
+/// This struct is NOT Clone or Copy because the underlying C++ handle
+/// must only be owned by one Rust instance at a time.
 pub struct Calc {
     pub(crate) handle: *mut CalcHandle,
 }


### PR DESCRIPTION
- Replace Mutex-based pool with thread_local! (matches C++ pattern)
- ThreadCalc::new() returns singleton per thread
- Implement RoxCalcExt trait for ThreadCalc
- Remove unsafe Send/Sync and Clone from Calc
- Remove parking_lot and once_cell dependencies
- Add multithread example demonstrating parallel chart calculation
- Bump version to 0.4.2